### PR TITLE
config: add staging to release-ghcr and sdd-sync workflows

### DIFF
--- a/.github/workflows/release-ghcr.yml
+++ b/.github/workflows/release-ghcr.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - staging
       - develop
   workflow_dispatch:
     inputs:

--- a/.github/workflows/sdd-sync.yml
+++ b/.github/workflows/sdd-sync.yml
@@ -2,7 +2,7 @@ name: SDD Issues Sync v2
 
 on:
   push:
-    branches: [main, develop, 'feature/**', 'bugfix/**', 'hotfix/**', 'release/**', 'chore/**']
+    branches: [main, staging, develop, 'feature/**', 'bugfix/**', 'hotfix/**', 'release/**', 'chore/**']
     paths:
       - 'openspec/changes/**'
       - 'openspec/specs/**'


### PR DESCRIPTION
Add `staging` branch to push triggers in release-ghcr.yml and sdd-sync.yml workflows as part of git-environment-flow rollout.