### PR TITLE
chore(testing): coverage thresholds + CSRF waiver (COU-117)

### DIFF
--- a/openspec/specs/security/spec.md
+++ b/openspec/specs/security/spec.md
@@ -110,3 +110,22 @@ The `.env.example` file MUST document `JWT_SECRET` and `CORS_ORIGINS` as require
 - **THEN** `CORS_ORIGINS` is listed as a required variable
 - **AND** includes format description (e.g., "Comma-separated list of allowed origins")
 - **AND** includes an example value (e.g., `https://app.example.com,https://admin.example.com`)
+
+### Requirement: SEC-05 — CSRF Protection Waiver
+
+This API uses JWT Bearer token authentication exclusively via the `Authorization` header (`ExtractJwt.fromAuthHeaderAsBearerToken()`). No cookies are set by the server. CORS is configured with `credentials: false`. Refresh tokens are passed in request body JSON, not in httpOnly cookies. Therefore, CSRF is not an applicable attack vector.
+
+**Waiver**: CSRF protection is explicitly waived. If cookie-based authentication is ever introduced, CSRF protection MUST be added at that time.
+
+#### Scenario: CSRF not needed for JWT Bearer auth
+- **GIVEN** the API authenticates via `Authorization: Bearer <token>` header
+- **AND** no cookies are set by the server
+- **AND** CORS `credentials: false`
+- **WHEN** a cross-origin request arrives without a valid Bearer token
+- **THEN** the request is rejected with 401 Unauthorized
+- **AND** no CSRF token validation is required
+
+#### Scenario: CSRF waiver invalidated if cookies added
+- **GIVEN** a future change introduces cookie-based authentication (session, refresh token in httpOnly cookie)
+- **WHEN** the security spec is reviewed
+- **THEN** CSRF protection MUST be implemented before merging that change

--- a/package.json
+++ b/package.json
@@ -106,9 +106,20 @@
     },
     "collectCoverageFrom": [
       "**/*.{!(module),}.(t|j)s",
-      "test/**/*.{t|j)s"
+      "!**/*.spec.ts",
+      "!**/*.mock.ts",
+      "!**/main.ts",
+      "!**/database/seeds/**"
     ],
     "coverageDirectory": "../coverage",
+    "coverageThreshold": {
+      "global": {
+        "statements": 55,
+        "branches": 45,
+        "functions": 35,
+        "lines": 55
+      }
+    },
     "testEnvironment": "node",
     "testTimeout": 30000
   }


### PR DESCRIPTION
Closes #314

## Summary
- **Coverage thresholds**: Added jest coverageThreshold (55/45/35/55 statements/branches/functions/lines) — conservative floor at current baseline
- **Glob fix**: Fixed collectCoverageFrom bug ( missing brace) — now excludes spec, mock, seeds, main.ts
- **CSRF waiver**: Documented SEC-05 in security spec — JWT Bearer auth only, no cookies, credentials: false, CSRF not applicable

## Test Plan
- [x] `npm run test:cov` — 359 tests, 42 suites, ALL PASS
- [x] Coverage thresholds met (55/45/35/55)
- [x] No cookies set by server (grep verified)

## Linear
[COU-117](https://linear.app/countergank/issue/COU-117/cycle-5-test-coverage-csrf-waiver)