### PR TITLE
chore(test): migrate e2e harness to Fastify (COU-120)

### DIFF
--- a/src/config/custom-module-options/config-module-option.ts
+++ b/src/config/custom-module-options/config-module-option.ts
@@ -1,10 +1,15 @@
 import { isProd } from '../../common/utils';
 import { validate } from '../env.validation';
 
+// Jest sets JEST_WORKER_ID in every test worker. When present, ignore .env
+// files so @nestjs/config uses process.env values injected by jest.setup.ts
+// (which point to localhost, not docker-internal hostnames like db-user).
+const isTestRunner = !!process.env.JEST_WORKER_ID;
+
 export const ConfigModuleOption = {
   isGlobal: true,
   cache: true,
   envFilePath: `.env.${process.env.NODE_ENV || 'local'}`,
-  ignoreEnvFile: !!isProd(),
+  ignoreEnvFile: !!isProd() || isTestRunner,
   validate: validate,
 };

--- a/src/config/custom-module-options/mongoose-module-option.spec.ts
+++ b/src/config/custom-module-options/mongoose-module-option.spec.ts
@@ -2,57 +2,105 @@ import { ConfigService } from '@nestjs/config';
 import { MongooseModuleOption } from './mongoose-module-option';
 
 describe(MongooseModuleOption.name, () => {
-  it('should build MongoDB URI with user and password', () => {
-    const configService = {
-      getOrThrow: jest.fn((key: string) => {
-        const config: Record<string, string> = {
-          DATABASE_USER: 'testuser',
-          DATABASE_PASSWORD: 'testpass',
-          DATABASE_HOST: 'localhost',
-          DATABASE_PORT: '27017',
-          DATABASE_NAME: 'testdb',
-        };
-        return config[key];
-      }),
-      get: jest.fn((key: string, defaultValue?: string) => {
-        if (key === 'DATABASE_REPLICA_SET') return defaultValue ?? 'rs0';
-        return undefined;
-      }),
-    } as unknown as ConfigService;
+  const originalJestWorkerId = process.env.JEST_WORKER_ID;
 
-    const option = new MongooseModuleOption(configService);
-    const result = option.createMongooseOptions();
-
-    expect(result.uri).toBe('mongodb://testuser:testpass@localhost:27017/testdb?authSource=admin&replicaSet=rs0');
+  afterEach(() => {
+    // Restore JEST_WORKER_ID so one test's env mutation cannot leak into siblings
+    if (originalJestWorkerId === undefined) {
+      delete process.env.JEST_WORKER_ID;
+    } else {
+      process.env.JEST_WORKER_ID = originalJestWorkerId;
+    }
   });
 
-  it('should include credentials in URI for all configured values', () => {
-    const configService = {
-      getOrThrow: jest.fn((key: string) => {
-        const config: Record<string, string> = {
-          DATABASE_USER: 'admin',
-          DATABASE_PASSWORD: 's3cret!',
-          DATABASE_HOST: 'mongo.example.com',
-          DATABASE_PORT: '27018',
-          DATABASE_NAME: 'production_db',
-        };
-        return config[key];
-      }),
+  const buildConfigService = (config: Record<string, string>): ConfigService =>
+    ({
+      getOrThrow: jest.fn((key: string) => config[key]),
       get: jest.fn((key: string, defaultValue?: string) => {
         if (key === 'DATABASE_REPLICA_SET') return defaultValue ?? 'rs0';
         return undefined;
       }),
-    } as unknown as ConfigService;
+    }) as unknown as ConfigService;
 
-    const option = new MongooseModuleOption(configService);
-    const result = option.createMongooseOptions();
+  describe('production/dev mode (no JEST_WORKER_ID)', () => {
+    beforeEach(() => {
+      delete process.env.JEST_WORKER_ID;
+    });
 
-    expect(result.uri).toContain('admin');
-    expect(result.uri).toContain('s3cret!');
-    expect(result.uri).toContain('mongo.example.com');
-    expect(result.uri).toContain('27018');
-    expect(result.uri).toContain('production_db');
-    expect(result.uri).toContain('replicaSet=rs0');
-    expect(result.uri).toBe('mongodb://admin:s3cret!@mongo.example.com:27018/production_db?authSource=admin&replicaSet=rs0');
+    it('should build MongoDB URI with replicaSet when not under Jest', () => {
+      const configService = buildConfigService({
+        DATABASE_USER: 'testuser',
+        DATABASE_PASSWORD: 'testpass',
+        DATABASE_HOST: 'localhost',
+        DATABASE_PORT: '27017',
+        DATABASE_NAME: 'testdb',
+      });
+
+      const option = new MongooseModuleOption(configService);
+      const result = option.createMongooseOptions();
+
+      expect(result.uri).toBe(
+        'mongodb://testuser:testpass@localhost:27017/testdb?authSource=admin&replicaSet=rs0',
+      );
+    });
+
+    it('should include credentials and replicaSet in URI for all configured values', () => {
+      const configService = buildConfigService({
+        DATABASE_USER: 'admin',
+        DATABASE_PASSWORD: 's3cret!',
+        DATABASE_HOST: 'mongo.example.com',
+        DATABASE_PORT: '27018',
+        DATABASE_NAME: 'production_db',
+      });
+
+      const option = new MongooseModuleOption(configService);
+      const result = option.createMongooseOptions();
+
+      expect(result.uri).toBe(
+        'mongodb://admin:s3cret!@mongo.example.com:27018/production_db?authSource=admin&replicaSet=rs0',
+      );
+    });
+  });
+
+  describe('test mode (JEST_WORKER_ID set)', () => {
+    beforeEach(() => {
+      process.env.JEST_WORKER_ID = '1';
+    });
+
+    it('should use directConnection instead of replicaSet under Jest', () => {
+      const configService = buildConfigService({
+        DATABASE_USER: 'dev_user',
+        DATABASE_PASSWORD: 'dev_password',
+        DATABASE_HOST: 'localhost',
+        DATABASE_PORT: '27017',
+        DATABASE_NAME: 'api_user_test',
+      });
+
+      const option = new MongooseModuleOption(configService);
+      const result = option.createMongooseOptions();
+
+      expect(result.uri).toBe(
+        'mongodb://dev_user:dev_password@localhost:27017/api_user_test?authSource=admin&directConnection=true',
+      );
+      expect(result.uri).not.toContain('replicaSet');
+    });
+
+    it('should still include credentials in directConnection mode', () => {
+      const configService = buildConfigService({
+        DATABASE_USER: 'admin',
+        DATABASE_PASSWORD: 's3cret!',
+        DATABASE_HOST: 'mongo.example.com',
+        DATABASE_PORT: '27018',
+        DATABASE_NAME: 'production_db',
+      });
+
+      const option = new MongooseModuleOption(configService);
+      const result = option.createMongooseOptions();
+
+      expect(result.uri).toContain('admin');
+      expect(result.uri).toContain('s3cret!');
+      expect(result.uri).toContain('directConnection=true');
+      expect(result.uri).not.toContain('replicaSet');
+    });
   });
 });

--- a/src/config/custom-module-options/mongoose-module-option.ts
+++ b/src/config/custom-module-options/mongoose-module-option.ts
@@ -13,7 +13,17 @@ export class MongooseModuleOption implements MongooseOptionsFactory {
     const port = this.configService.getOrThrow('DATABASE_PORT');
     const database = this.configService.getOrThrow('DATABASE_NAME');
     const replicaSet = this.configService.get<string>('DATABASE_REPLICA_SET', 'rs0');
-    const uri = `mongodb://${user}:${password}@${host}:${port}/${database}?authSource=admin&replicaSet=${replicaSet}`;
+
+    // When connecting from outside the docker network (e.g. e2e tests from the
+    // host), the replica set member is registered as the docker hostname
+    // (db-user:27017). The driver discovers it and fails with EAI_AGAIN. Use
+    // directConnection to skip replica set topology discovery.
+    const directConnection = process.env.JEST_WORKER_ID !== undefined;
+
+    const queryParams = directConnection
+      ? 'authSource=admin&directConnection=true'
+      : `authSource=admin&replicaSet=${replicaSet}`;
+    const uri = `mongodb://${user}:${password}@${host}:${port}/${database}?${queryParams}`;
     return {
       uri: uri,
     };

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -7,7 +7,7 @@ describe('AppController (e2e)', () => {
 
   beforeAll(async () => {
     app = await createTestApp();
-  });
+  }, 60000);
 
   afterAll(async () => {
     await app.close();

--- a/test/helpers/create-test-app.ts
+++ b/test/helpers/create-test-app.ts
@@ -1,5 +1,6 @@
 import { INestApplication, ValidationPipe } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
+import { FastifyAdapter, NestFastifyApplication } from '@nestjs/platform-fastify';
 import { AppModule } from '../../src/app/app.module';
 
 export async function createTestApp(): Promise<INestApplication> {
@@ -7,7 +8,8 @@ export async function createTestApp(): Promise<INestApplication> {
     imports: [AppModule],
   }).compile();
 
-  const app = moduleFixture.createNestApplication();
+  const adapter = new FastifyAdapter({ logger: false });
+  const app = moduleFixture.createNestApplication<NestFastifyApplication>(adapter);
   app.useGlobalPipes(
     new ValidationPipe({
       whitelist: true,
@@ -19,6 +21,7 @@ export async function createTestApp(): Promise<INestApplication> {
     }),
   );
   await app.init();
+  await app.listen(0);
 
   return app;
 }


### PR DESCRIPTION
## Summary

Unblocks all 7 e2e specs under `test/` that timed out during `beforeAll` due to a chain of 5 pre-existing harness bugs. None of the bugs were in the admin-crud feature code (COU-77, COU-78), which is already merged and unit-tested green.

## Changes

- **`config-module-option.ts`**: Set `ignoreEnvFile` under Jest so `@nestjs/config` reads `process.env` from `jest.setup.ts` instead of `.env.development` (which pins `DATABASE_HOST=db-user`, unreachable from the host).
- **`mongoose-module-option.ts`**: Use `directConnection=true` under Jest to skip replica set topology discovery — the driver otherwise resolves the docker-internal member hostname `db-user:27017` and fails with `EAI_AGAIN`.
- **`create-test-app.ts`**: Build with `FastifyAdapter` (matches `main.ts`) and call `app.listen(0)` after init so supertest can reach the server — the old Express adapter caused `AuditInterceptor`'s `response.raw.on` to throw because that property only exists on Fastify replies.
- **`mongoose-module-option.spec.ts`**: Cover both production (replicaSet) and Jest (directConnection) URI modes.
- **`app.e2e-spec.ts`**: Bump `beforeAll` timeout to 60s for CI.

## Testing

- `test/user/admin-crud-pagination.e2e-spec.ts`: 15/15 green
- `test/app.e2e-spec.ts`: 1/1 green
- `src/config/custom-module-options/mongoose-module-option.spec.ts`: 4/4 green
- `src/user/controller/user.controller.spec.ts`: 30/30 green
- `src/common/audit/audit.interceptor.spec.ts`: 23/23 green
- Pre-push hook (husky): 42 suites / 361 tests — all green

## Screenshots (optional)

N/A

## Self-review Checklist

- [x] Code follows project conventions and style guide
- [x] Self-reviewed the diff for typos, dead code, and debug leftovers
- [x] Added or updated tests for new/changed behavior
- [ ] Documentation updated (README, comments, API docs)
- [x] Commit messages follow Conventional Commits format
- [x] No unrelated changes included in this PR

## Related Issues

Refs COU-120
