### PR TITLE
feat(cache): add CacheService with Redis backend — COU-145

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -11,6 +11,7 @@ import { ConfigModuleOption } from '../config/custom-module-options/config-modul
 import { MongooseModuleOption } from '../config/custom-module-options/mongoose-module-option';
 import { ExampleMicroservice } from '../config/custom-providers/microservices';
 import { RedisModule } from '../config/redis/redis.module';
+import { CacheModule } from '../config/cache/cache.module';
 import { UserModule } from '../user/user.module';
 import { AuthModule } from '../auth/auth.module';
 import { RbacModule } from '../rbac/rbac.module';
@@ -57,6 +58,7 @@ import { AppService } from './service/app.service';
     }),
     TerminusModule,
     RedisModule,
+    CacheModule,
     I18nModule,
     AuditModule,
     UserModule,

--- a/src/config/cache/cache.module.ts
+++ b/src/config/cache/cache.module.ts
@@ -1,0 +1,9 @@
+import { Module, Global } from '@nestjs/common';
+import { CacheService } from './cache.service';
+
+@Global()
+@Module({
+  providers: [CacheService],
+  exports: [CacheService],
+})
+export class CacheModule {}

--- a/src/config/cache/cache.service.spec.ts
+++ b/src/config/cache/cache.service.spec.ts
@@ -1,0 +1,259 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CacheService } from './cache.service';
+import { RedisService } from '../redis/redis.service';
+
+describe(CacheService.name, () => {
+  let service: CacheService;
+
+  const mockRedisService = {
+    get: jest.fn(),
+    set: jest.fn(),
+    del: jest.fn(),
+    getClient: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    jest.resetAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CacheService,
+        { provide: RedisService, useValue: mockRedisService },
+      ],
+    }).compile();
+
+    service = module.get<CacheService>(CacheService);
+  });
+
+  afterEach(() => {
+    service.onModuleDestroy();
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe(`${CacheService.name}.get`, () => {
+    it('should return parsed data when key exists and not expired', async () => {
+      const key = 'user:123';
+      const data = { name: 'John', age: 30 };
+      const entry = { data, expiresAt: Date.now() + 60_000 };
+      mockRedisService.get.mockResolvedValue(JSON.stringify(entry));
+
+      const result = await service.get<typeof data>(key);
+
+      expect(result).toEqual(data);
+      expect(mockRedisService.get).toHaveBeenCalledWith(`cache:${key}`);
+    });
+
+    it('should return undefined when key does not exist', async () => {
+      mockRedisService.get.mockResolvedValue(null);
+
+      const result = await service.get('nonexistent');
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should return undefined when Redis throws an error', async () => {
+      mockRedisService.get.mockRejectedValue(new Error('Redis connection lost'));
+
+      const result = await service.get('failing-key');
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should increment miss counter on cache miss', async () => {
+      mockRedisService.get.mockResolvedValue(null);
+
+      await service.get('miss-key');
+
+      const stats = service.stats();
+      expect(stats.misses).toBe(1);
+      expect(stats.hits).toBe(0);
+    });
+
+    it('should increment hit counter on cache hit', async () => {
+      const entry = { data: 'test', expiresAt: null };
+      mockRedisService.get.mockResolvedValue(JSON.stringify(entry));
+
+      await service.get('hit-key');
+
+      const stats = service.stats();
+      expect(stats.hits).toBe(1);
+      expect(stats.misses).toBe(0);
+    });
+
+    it('should delete and return undefined for expired entries', async () => {
+      const key = 'expired-key';
+      const expiresAt = Date.now() - 1000;
+      const entry = { data: 'old', expiresAt };
+      mockRedisService.get.mockResolvedValue(JSON.stringify(entry));
+      mockRedisService.del.mockResolvedValue(undefined);
+
+      const result = await service.get(key);
+
+      expect(result).toBeUndefined();
+      expect(mockRedisService.del).toHaveBeenCalledWith(`cache:${key}`);
+    });
+
+    it('should treat entries without expiresAt as never expired', async () => {
+      const key = 'permanent-key';
+      const entry = { data: { nested: true }, expiresAt: null };
+      mockRedisService.get.mockResolvedValue(JSON.stringify(entry));
+
+      const result = await service.get<typeof entry['data']>(key);
+
+      expect(result).toEqual({ nested: true });
+    });
+  });
+
+  describe(`${CacheService.name}.set`, () => {
+    it('should store value with default TTL', async () => {
+      const key = 'config:db';
+      const value = { host: 'localhost' };
+
+      await service.set(key, value);
+
+      expect(mockRedisService.set).toHaveBeenCalledWith(
+        `cache:${key}`,
+        expect.stringContaining(JSON.stringify(value)),
+        300,
+      );
+    });
+
+    it('should store value with custom TTL', async () => {
+      const key = 'session:abc';
+      const value = { userId: '123' };
+      const ttlMs = 60_000;
+
+      await service.set(key, value, ttlMs);
+
+      expect(mockRedisService.set).toHaveBeenCalledWith(
+        `cache:${key}`,
+        expect.stringContaining(JSON.stringify(value)),
+        60,
+      );
+    });
+
+    it('should include expiresAt metadata in stored entry', async () => {
+      const key = 'test:meta';
+      const before = Date.now();
+
+      await service.set(key, { val: 1 }, 10_000);
+
+      const storedJson = mockRedisService.set.mock.calls[0][1];
+      const entry = JSON.parse(storedJson);
+
+      expect(entry).toHaveProperty('data');
+      expect(entry).toHaveProperty('expiresAt');
+      expect(entry.expiresAt).toBeGreaterThanOrEqual(before + 10_000);
+      expect(entry.expiresAt).toBeLessThanOrEqual(before + 10_001);
+    });
+
+    it('should not throw when Redis set fails', async () => {
+      mockRedisService.set.mockRejectedValue(new Error('Redis write failed'));
+
+      await expect(
+        service.set('fail-key', { data: 'test' }),
+      ).resolves.not.toThrow();
+    });
+  });
+
+  describe(`${CacheService.name}.del`, () => {
+    it('should delete a single key with prefix', async () => {
+      await service.del('remove-me');
+
+      expect(mockRedisService.del).toHaveBeenCalledWith('cache:remove-me');
+    });
+
+    it('should not throw when Redis del fails', async () => {
+      mockRedisService.del.mockRejectedValue(new Error('Redis del failed'));
+
+      await expect(service.del('fail-key')).resolves.not.toThrow();
+    });
+  });
+
+  describe(`${CacheService.name}.delByPattern`, () => {
+    it('should delete keys matching pattern using SCAN', async () => {
+      const mockClient = {
+        scan: jest.fn(),
+      };
+      mockRedisService.getClient.mockReturnValue(mockClient);
+
+      mockClient.scan
+        .mockResolvedValueOnce(['120', ['cache:user:1', 'cache:user:2']])
+        .mockResolvedValueOnce(['0', ['cache:user:3']]);
+
+      const deletedCount = await service.delByPattern('cache:user:*');
+
+      expect(deletedCount).toBe(3);
+      expect(mockClient.scan).toHaveBeenCalledTimes(2);
+      expect(mockClient.scan).toHaveBeenCalledWith('0', 'MATCH', 'cache:user:*', 'COUNT', 100);
+      expect(mockRedisService.del).toHaveBeenCalledTimes(3);
+    });
+
+    it('should return 0 when no keys match', async () => {
+      const mockClient = {
+        scan: jest.fn().mockResolvedValue(['0', []]),
+      };
+      mockRedisService.getClient.mockReturnValue(mockClient);
+
+      const deletedCount = await service.delByPattern('cache:nonexistent:*');
+
+      expect(deletedCount).toBe(0);
+    });
+
+    it('should return 0 when SCAN throws an error', async () => {
+      const mockClient = {
+        scan: jest.fn().mockRejectedValue(new Error('SCAN failed')),
+      };
+      mockRedisService.getClient.mockReturnValue(mockClient);
+
+      const deletedCount = await service.delByPattern('cache:bad:*');
+
+      expect(deletedCount).toBe(0);
+    });
+  });
+
+  describe(`${CacheService.name}.stats`, () => {
+    it('should return initial stats with zero counters', () => {
+      const stats = service.stats();
+
+      expect(stats.hits).toBe(0);
+      expect(stats.misses).toBe(0);
+      expect(stats.hitRate).toBe(0);
+    });
+
+    it('should calculate correct hit rate', async () => {
+      const hitEntry = { data: { v: 1 }, expiresAt: null };
+      mockRedisService.get
+        .mockResolvedValueOnce(JSON.stringify(hitEntry))
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(JSON.stringify(hitEntry));
+
+      await service.get('key1');
+      await service.get('key2');
+      await service.get('key3');
+
+      const stats = service.stats();
+      expect(stats.hits).toBe(2);
+      expect(stats.misses).toBe(1);
+      expect(stats.hitRate).toBeCloseTo(0.667, 2);
+    });
+  });
+
+  describe(`${CacheService.name}.resetStats`, () => {
+    it('should reset all counters to zero', async () => {
+      const entry = { data: 1, expiresAt: null };
+      mockRedisService.get.mockResolvedValue(JSON.stringify(entry));
+      await service.get('some-key');
+
+      service.resetStats();
+
+      const stats = service.stats();
+      expect(stats.hits).toBe(0);
+      expect(stats.misses).toBe(0);
+      expect(stats.hitRate).toBe(0);
+    });
+  });
+});

--- a/src/config/cache/cache.service.ts
+++ b/src/config/cache/cache.service.ts
@@ -1,0 +1,156 @@
+import { Injectable, Logger, OnModuleDestroy } from '@nestjs/common';
+import { RedisService } from '../redis/redis.service';
+
+const DEFAULT_PREFIX = 'cache:';
+const DEFAULT_TTL_SECONDS = 300; // 5 minutes
+const SCAN_COUNT = 100;
+const CLEANUP_INTERVAL_MS = 60_000; // 1 minute
+
+interface CacheEntry<T> {
+  data: T;
+  expiresAt: number | null;
+}
+
+@Injectable()
+export class CacheService implements OnModuleDestroy {
+  private readonly logger = new Logger(CacheService.name);
+  private readonly cleanupTimer: ReturnType<typeof setInterval> | null = null;
+
+  private hits = 0;
+  private misses = 0;
+
+  constructor(private readonly redisService: RedisService) {
+    this.cleanupTimer = setInterval(() => {
+      this.cleanupExpired().catch((err) => {
+        this.logger.error(`Cleanup error: ${(err as Error).message}`);
+      });
+    }, CLEANUP_INTERVAL_MS);
+
+    if (this.cleanupTimer.unref) {
+      this.cleanupTimer.unref();
+    }
+  }
+
+  async onModuleDestroy() {
+    if (this.cleanupTimer) {
+      clearInterval(this.cleanupTimer);
+    }
+  }
+
+  async get<T>(key: string): Promise<T | undefined> {
+    try {
+      const raw = await this.redisService.get(this.prefixedKey(key));
+      if (raw === null) {
+        this.misses++;
+        return undefined;
+      }
+
+      const entry: CacheEntry<T> = JSON.parse(raw);
+
+      if (entry.expiresAt && Date.now() > entry.expiresAt) {
+        await this.redisService.del(this.prefixedKey(key));
+        this.misses++;
+        return undefined;
+      }
+
+      this.hits++;
+      return entry.data;
+    } catch (error) {
+      this.logger.error(`Cache get error for key "${key}": ${(error as Error).message}`);
+      this.misses++;
+      return undefined;
+    }
+  }
+
+  async set<T>(key: string, value: T, ttlMs?: number): Promise<void> {
+    try {
+      const effectiveTtlMs = ttlMs ?? DEFAULT_TTL_SECONDS * 1000;
+      const ttlSeconds = Math.ceil(effectiveTtlMs / 1000);
+      const expiresAt = Date.now() + effectiveTtlMs;
+
+      const entry: CacheEntry<T> = { data: value, expiresAt };
+      await this.redisService.set(this.prefixedKey(key), JSON.stringify(entry), ttlSeconds);
+    } catch (error) {
+      this.logger.error(`Cache set error for key "${key}": ${(error as Error).message}`);
+    }
+  }
+
+  async del(key: string): Promise<void> {
+    try {
+      await this.redisService.del(this.prefixedKey(key));
+    } catch (error) {
+      this.logger.error(`Cache del error for key "${key}": ${(error as Error).message}`);
+    }
+  }
+
+  async delByPattern(pattern: string): Promise<number> {
+    try {
+      const client = this.redisService.getClient();
+      let cursor = '0';
+      let totalDeleted = 0;
+
+      do {
+        const [nextCursor, keys] = await client.scan(cursor, 'MATCH', pattern, 'COUNT', SCAN_COUNT);
+        cursor = nextCursor;
+
+        if (keys.length > 0) {
+          await Promise.all(keys.map((k) => this.redisService.del(k)));
+          totalDeleted += keys.length;
+        }
+      } while (cursor !== '0');
+
+      return totalDeleted;
+    } catch (error) {
+      this.logger.error(`Cache delByPattern error for pattern "${pattern}": ${(error as Error).message}`);
+      return 0;
+    }
+  }
+
+  stats(): { hits: number; misses: number; hitRate: number } {
+    const total = this.hits + this.misses;
+    return {
+      hits: this.hits,
+      misses: this.misses,
+      hitRate: total > 0 ? this.hits / total : 0,
+    };
+  }
+
+  resetStats(): void {
+    this.hits = 0;
+    this.misses = 0;
+  }
+
+  private prefixedKey(key: string): string {
+    return `${DEFAULT_PREFIX}${key}`;
+  }
+
+  private async cleanupExpired(): Promise<void> {
+    try {
+      const client = this.redisService.getClient();
+      let cursor = '0';
+      const now = Date.now();
+
+      do {
+        const [nextCursor, keys] = await client.scan(cursor, 'MATCH', `${DEFAULT_PREFIX}*`, 'COUNT', SCAN_COUNT);
+        cursor = nextCursor;
+
+        for (const key of keys) {
+          const raw = await this.redisService.get(key);
+          if (raw === null) continue;
+
+          try {
+            const entry: CacheEntry<unknown> = JSON.parse(raw);
+            if (entry.expiresAt && now > entry.expiresAt) {
+              await this.redisService.del(key);
+            }
+          } catch {
+            // Corrupted entry — delete it
+            await this.redisService.del(key);
+          }
+        }
+      } while (cursor !== '0');
+    } catch (error) {
+      this.logger.error(`Cleanup expired error: ${(error as Error).message}`);
+    }
+  }
+}

--- a/src/config/cache/index.ts
+++ b/src/config/cache/index.ts
@@ -1,0 +1,2 @@
+export { CacheService } from './cache.service';
+export { CacheModule } from './cache.module';


### PR DESCRIPTION
## Summary

Generic CacheService backed by Redis (COU-156) with SCAN-based invalidation, TTL support, and hit/miss stats.

## Changes

| File | Action | Description |
|------|--------|-------------|
| src/config/cache/cache.service.ts | Created | CacheService: get/set/del/delByPattern/stats/resetStats |
| src/config/cache/cache.module.ts | Created | @Global NestJS module exporting CacheService |
| src/config/cache/index.ts | Created | Barrel exports |
| src/config/cache/cache.service.spec.ts | Created | 20 unit tests |
| src/app/app.module.ts | Modified | Import CacheModule |

## Key Design Decisions

- **SCAN-based delByPattern**: Uses cursor iteration (batch 100), not KEYS — safe for production
- **Lazy expiration**: Redis EXPIRE + expiresAt metadata check on get
- **Graceful degradation**: All Redis errors caught and logged, never thrown
- **In-memory stats**: Hit/miss counters in the NestJS process, not Redis
- **Key prefix**: `cache:` to namespace cache entries

## Testing

- 20 unit tests passing
- 353 total tests passing
- TypeScript compiles clean

## Next Steps

- COU-146: Cache User (consume CacheService for JWT validation)
- COU-147: Cache RBAC (consume CacheService for roles/permissions)
