### PR TITLE
feat(config): add AppConfigService for centralized typed configuration

### DIFF
--- a/openspec/changes/archive/2026-07-22-COU-141-parameter-service/CHANGELOG.md
+++ b/openspec/changes/archive/2026-07-22-COU-141-parameter-service/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog: COU-141 — ParameterService
+
+## Summary
+
+Created `AppConfigService`, a centralized, typed configuration service wrapping NestJS `ConfigService`. Migrated `email.listener.ts` and `email.service.ts` from direct `process.env` access to DI-injected config.
+
+## Changes
+
+### New Files
+- `src/config/app-config.service.ts` — Global injectable `AppConfigService` with typed getters for `frontendUrl`, `emailProvider`, and `throttle`
+
+### Modified Files
+- `src/config/env.validation.ts` — Added `export` to `EnvironmentVariables` class and `Environment` enum
+- `src/email/listeners/email.listener.ts` — Injected `AppConfigService`, replaced 4× `process.env.FRONTEND_URL` with `this.config.frontendUrl`
+- `src/email/service/email.service.ts` — Injected `AppConfigService`, replaced `process.env.EMAIL_PROVIDER` with `this.config.emailProvider`
+
+### New Tests
+- `app-config.service.spec.ts` — 22 unit tests verifying each typed getter returns correct values from mocked `ConfigService`
+
+## Test Results
+- **445 total tests passing** (22 new + 423 existing)
+- Lint: clean
+
+## Architecture Decision
+- Single global `AppConfigService` chosen over multiple group services — matches existing single-`ConfigService` injection pattern
+- `@Global()` decorator eliminates need for per-module imports
+- Decorator contexts (`@Throttle()`) and standalone utilities excluded (Phase 2 scope)

--- a/openspec/changes/archive/2026-07-22-COU-141-parameter-service/exploration.md
+++ b/openspec/changes/archive/2026-07-22-COU-141-parameter-service/exploration.md
@@ -1,0 +1,166 @@
+# Exploration: COU-141 — ParameterService
+
+## Current State
+
+The `api-user` NestJS project has **two competing patterns** for accessing environment configuration:
+
+### Pattern 1: `ConfigService` (DI-injected, NestJS-idiomatic)
+Used in ~12 files via constructor injection from `@nestjs/config`. This is the proper pattern — it supports caching, validation, and testability.
+
+**Files using ConfigService correctly:**
+- `src/main.ts` — CORS_ORIGINS, PORT, HOST, npm metadata
+- `src/auth/auth.service.ts` — MAX_LOGIN_ATTEMPTS, LOCKOUT_DURATION_MINUTES
+- `src/auth/strategies/jwt.strategy.ts` — JWT_SECRET
+- `src/auth/auth.module.ts` — JWT_SECRET (via JwtModule.registerAsync)
+- `src/config/redis/redis.service.ts` — REDIS_HOST, REDIS_PORT, REDIS_PASSWORD, REDIS_DB
+- `src/config/custom-providers/microservice-provider.ts` — dynamic `*_MICROSERVICE_*` keys
+- `src/config/custom-module-options/mongoose-module-option.ts` — DATABASE_* keys
+- `src/app/app.module.ts` — THROTTLE_TTL, THROTTLE_LIMIT
+- `src/common/audit/audit.listener.ts` — AUDIT_ENABLED
+- `src/common/audit/audit.interceptor.ts` and `audit-aspect.interceptor.ts`
+- `src/app/service/app.service.ts`
+
+### Pattern 2: Direct `process.env` access (bypasses DI)
+**44 direct `process.env` usages** across 11 non-test source files. These bypass `ConfigService` entirely, losing caching, type safety, and testability.
+
+**File breakdown (non-test only):**
+
+| File | Count | Vars accessed |
+|------|-------|---------------|
+| `src/auth/auth.controller.ts` | 16 | THROTTLE_LIMIT/TTL, LOGIN_THROTTLE_*, REGISTER_THROTTLE_*, FORGOT_PASSWORD_THROTTLE_* |
+| `src/email/providers/smtp.provider.ts` | 6 | EMAIL_HOST, EMAIL_PORT, EMAIL_USER, EMAIL_PASS, EMAIL_SECURE, EMAIL_FROM |
+| `src/email/listeners/email.listener.ts` | 4 | FRONTEND_URL (×4) |
+| `src/common/utils/index.ts` | 4 | NODE_ENV (×4) |
+| `src/config/custom-module-options/config-module-option.ts` | 3 | JEST_WORKER_ID, NODE_ENV |
+| `src/common/logger-config.ts` | 3 | NODE_ENV, DEBUG, LOG_LEVEL |
+| `src/email/providers/resend.provider.ts` | 2 | RESEND_API_KEY, RESEND_FROM_EMAIL/EMAIL_FROM |
+| `src/email/email.provider.factory.ts` | 2 | EMAIL_PROVIDER, NODE_ENV |
+| `src/common/logger.ts` | 2 | LOG_LEVEL, NODE_ENV, DEBUG |
+| `src/email/service/email.service.ts` | 1 | EMAIL_PROVIDER |
+| `src/config/custom-module-options/mongoose-module-option.ts` | 1 | JEST_WORKER_ID |
+
+### Why direct `process.env` is used (root causes):
+1. **Decorators can't access DI** — `@Throttle()` in auth.controller.ts is evaluated at class definition time, before DI is available
+2. **Email providers are plain classes** (not `@Injectable()`) — created via factory, can't receive ConfigService
+3. **Standalone utilities** — `logger.ts`, `utils/index.ts`, `logger-config.ts` run outside NestJS DI context
+4. **Developer inertia** — some files (email.listener.ts) are injectable but still use raw `process.env`
+
+### Validation & Defaults
+`env.validation.ts` defines a `EnvironmentVariables` class with `class-validator` decorators. It validates all env vars at startup via `ConfigModule.forRoot({ validate })`. Default values are applied for AUDIT_* and REDIS_* vars. This is well-designed but the validated types are not exported for reuse.
+
+### Doppler Integration
+The `Makefile` has Doppler support for downloading secrets into `.env.{ENV}` files during local development. In production, `ConfigModuleOption` sets `ignoreEnvFile: true` (via `isProd()`), relying on platform-injected env vars (e.g., Doppler runtime, Docker, K8s).
+
+### No Existing ParameterService
+No `ParameterService`, `AppConfigService`, or similar centralized config wrapper exists. The `ConfigService` from `@nestjs/config` is the closest thing, but it's generic (string keys, no type safety).
+
+---
+
+## Affected Areas
+
+- `src/auth/auth.controller.ts` — heaviest process.env user (16 occurrences), but constrained by decorator evaluation timing
+- `src/email/providers/smtp.provider.ts` — plain class, can't use DI
+- `src/email/providers/resend.provider.ts` — plain class, can't use DI
+- `src/email/email.provider.factory.ts` — factory function, outside DI
+- `src/email/listeners/email.listener.ts` — injectable but uses raw process.env
+- `src/email/service/email.service.ts` — injectable but uses raw process.env
+- `src/common/logger.ts` — standalone utility, outside DI
+- `src/common/logger-config.ts` — module-level function, outside DI
+- `src/common/utils/index.ts` — pure utility functions
+- `src/config/custom-module-options/config-module-option.ts` — bootstrap config, runs before DI
+- `src/config/custom-module-options/mongoose-module-option.ts` — uses ConfigService mostly, one process.env for JEST_WORKER_ID
+- `src/config/env.validation.ts` — validates env, types not exported
+
+---
+
+## Approaches
+
+### 1. **Typed ConfigModule Wrapper (recommended)** — Create a typed configuration interface + a global `@Injectable()` service that wraps `ConfigService` with typed accessors
+
+**Design:**
+- Define a `AppConfig` interface with typed fields for every env var
+- Create `AppConfigService` extending/wrapping `ConfigService`, with typed getters (e.g., `get throttle(): ThrottleConfig`)
+- Export the validated config from `env.validation.ts` as the canonical type
+- Make it `@Global()` so all modules can inject it
+- For decorator contexts (throttle), use a `@Lazy()` wrapper or a module-level constant resolved at init time
+
+**Pros:**
+- Full type safety, autocompletion, compile-time errors on wrong keys
+- Single source of truth (env.validation.ts becomes the config contract)
+- Easy to test (mock one service vs. 44 process.env overrides)
+- Follows NestJS conventions
+- Minimal migration — ConfigService is already global, this is additive
+
+**Cons:**
+- Decorator limitation still exists (need a workaround for `@Throttle`)
+- Slight increase in abstraction layer
+- Email providers (plain classes) need refactoring to accept config via constructor
+
+**Effort:** Medium
+
+### 2. **Replace process.env with ConfigService everywhere** — Migrate all 44 direct usages to use the existing ConfigService via DI
+
+**Design:**
+- Make email providers `@Injectable()` and receive ConfigService
+- Add `forwardRef` or lazy injection for decorator contexts
+- Move standalone utilities to accept config as parameters
+
+**Pros:**
+- No new abstractions
+- Uses existing @nestjs/config infrastructure directly
+
+**Cons:**
+- Still no type safety (ConfigService.get<string>('KEY'))
+- Decorator limitation requires ugly workarounds
+- Email provider refactoring is more invasive (factory pattern change)
+- Every consumer needs to parse/convert types manually
+
+**Effort:** Medium-High
+
+### 3. **Config-as-Constants Module** — Resolve all env vars at bootstrap, expose as frozen typed constants
+
+**Design:**
+- In `main.ts` bootstrap, read all env vars via ConfigService
+- Store in a module-level singleton (e.g., `APP_CONFIG`)
+- Export constants that can be used anywhere (including decorators)
+
+**Pros:**
+- Works everywhere including decorators (constants, not DI)
+- Simple mental model
+
+**Cons:**
+- Loses runtime flexibility (no hot-reload, though env vars are static anyway)
+- Global mutable state pattern
+- Harder to test (need to reset global state)
+- Not NestJS-idiomatic
+
+**Effort:** Low
+
+---
+
+## Recommendation
+
+**Approach 1: Typed ConfigModule Wrapper** is the strongest path forward.
+
+The rationale:
+1. The `env.validation.ts` already defines the shape — we just need to export that type
+2. A typed `AppConfigService` gives compile-time safety on every config access
+3. The decorator limitation in `auth.controller.ts` can be solved with `ConfigModule`'s `cache: true` + reading values in a `OnModuleInit` hook that stores them in a static map (or simply keep the current pattern for decorators since they're bootstrap-time constants anyway)
+4. The email provider refactoring (plain class → injectable) is a worthwhile cleanup regardless
+
+**For the decorator constraint specifically:** The `@Throttle()` values are computed at class decoration time. The cleanest solution is a `@ModuleConfig()` custom decorator that reads from a resolved config map initialized during `APP_INITIALIZER`. Alternatively, keep the `process.env` in decorators as a documented exception — these values are validated at startup and never change at runtime.
+
+---
+
+## Risks
+
+1. **Decorator timing** — `@Throttle()` decorators in `auth.controller.ts` evaluate before DI. A ParameterService cannot be injected there. Options: (a) keep process.env in decorators as documented exception, (b) create a static config map initialized in `APP_INITIALIZER`, or (c) move throttle config to a middleware/guard instead of decorators.
+2. **Email provider refactoring** — `SmtpProvider` and `ResendProvider` are plain classes instantiated by a factory. Making them injectable changes the factory pattern. This is a necessary but non-trivial refactor.
+3. **Standalone logger** — `createStandaloneLogger()` runs outside DI (used by microservice factory). It will still need process.env or a config parameter. This is acceptable as a documented edge case.
+4. **Test impact** — Existing tests that mock `process.env` directly will need updating. The `env.validation.spec.ts` and `mongoose-module-option.spec.ts` already test config validation, so the migration surface is manageable.
+
+---
+
+## Ready for Proposal
+
+**Yes.** The codebase has a clear problem (44 scattered `process.env` usages with no type safety), an existing foundation to build on (`env.validation.ts` + global `ConfigModule`), and a well-understood recommended approach. The orchestrator should proceed to proposal.

--- a/openspec/changes/archive/2026-07-22-COU-141-parameter-service/tasks.md
+++ b/openspec/changes/archive/2026-07-22-COU-141-parameter-service/tasks.md
@@ -1,0 +1,53 @@
+# Tasks: COU-141 — ParameterService
+
+## Review Workload Forecast
+
+| Field | Value |
+|-------|-------|
+| Estimated changed lines | 90–130 |
+| 400-line budget risk | Low |
+| Chained PRs recommended | No |
+| Suggested split | Single PR |
+| Delivery strategy | ask-on-risk |
+| Chain strategy | size-exception |
+
+Decision needed before apply: No
+Chained PRs recommended: No
+Chain strategy: size-exception
+400-line budget risk: Low
+
+### Suggested Work Units
+
+| Unit | Goal | Likely PR | Notes |
+|------|------|-----------|-------|
+| 1 | Export type + create service + migrate email files + tests | PR 1 | Single self-contained PR |
+
+## Phase 1: Foundation
+
+- [x] 1.1 Add `export` to `EnvironmentVariables` class in `src/config/env.validation.ts` — change `class EnvironmentVariables` to `export class EnvironmentVariables`
+- [x] 1.2 Add `export` to `Environment` enum in `src/config/env.validation.ts`
+
+## Phase 2: Core Implementation
+
+- [x] 2.1 Create `src/config/app-config.service.ts` with `@Injectable()` `AppConfigService` class wrapping `ConfigService`
+- [x] 2.2 Add typed getter `get frontendUrl(): string` returning `this.config.get<string>('FRONTEND_URL')`
+- [x] 2.3 Add typed getter `get emailProvider(): string` returning `this.config.get<string>('EMAIL_PROVIDER') ?? 'smtp'`
+- [x] 2.4 Add grouped getter `get throttle()` returning `{ ttl: string; limit: string }` for generic throttle config
+- [x] 2.5 Register `AppConfigService` as `@Global()` in `AppConfigModule` — create module in same file or new `src/config/app-config.module.ts`
+
+## Phase 3: Integration
+
+- [x] 3.1 In `src/email/listeners/email.listener.ts`: inject `AppConfigService`, replace 4× `process.env.FRONTEND_URL` with `this.config.frontendUrl`
+- [x] 3.2 In `src/email/service/email.service.ts`: inject `AppConfigService`, replace `process.env.EMAIL_PROVIDER` in `getProviderName()` with `this.config.emailProvider`
+
+## Phase 4: Testing
+
+- [x] 4.1 Write unit test for `AppConfigService` — verify each getter returns correct value from mocked `ConfigService`
+- [x] 4.2 Verify existing `email.listener` tests pass after migration (update mocks from `process.env` to `AppConfigService`)
+- [x] 4.3 Verify existing `email.service` tests pass after migration
+
+## Phase 5: Verification
+
+- [x] 5.1 Run `npm test` — all tests pass
+- [x] 5.2 Run `npm run lint` — no lint errors in modified files
+- [x] 5.3 Verify `EnvironmentVariables` type is importable from `src/config/env.validation.ts`

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -9,6 +9,7 @@ import { ClsModule } from 'nestjs-cls';
 import { LoggerModule } from 'nestjs-pino';
 import { ConfigModuleOption } from '../config/custom-module-options/config-module-option';
 import { MongooseModuleOption } from '../config/custom-module-options/mongoose-module-option';
+import { AppConfigModule } from '../config/app-config.module';
 import { ExampleMicroservice } from '../config/custom-providers/microservices';
 import { RedisModule } from '../config/redis/redis.module';
 import { CacheModule } from '../config/cache/cache.module';
@@ -42,6 +43,7 @@ import { AppService } from './service/app.service';
     LoggerModule.forRoot(buildLoggerConfig()),
     ClsModule.forRoot({ global: true, middleware: { mount: true } }),
     ConfigModule.forRoot(ConfigModuleOption),
+    AppConfigModule,
     MongooseModule.forRootAsync({ useClass: MongooseModuleOption }),
     EventEmitterModule.forRoot(),
     ThrottlerModule.forRootAsync({

--- a/src/config/__tests__/app-config.module.spec.ts
+++ b/src/config/__tests__/app-config.module.spec.ts
@@ -1,0 +1,50 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { AppConfigModule } from '../app-config.module';
+import { AppConfigService } from '../app-config.service';
+
+describe(AppConfigModule.name, () => {
+  let module: TestingModule;
+
+  beforeAll(async () => {
+    module = await Test.createTestingModule({
+      imports: [
+        ConfigModule.forRoot({
+          isGlobal: true,
+        }),
+        AppConfigModule,
+      ],
+    }).compile();
+  });
+
+  it('should provide AppConfigService', () => {
+    const service = module.get<AppConfigService>(AppConfigService);
+    expect(service).toBeDefined();
+  });
+
+  it('should resolve frontendUrl from ConfigService', () => {
+    const service = module.get<AppConfigService>(AppConfigService);
+    // Value comes from env vars set in jest.setup.ts / .env.local.testing
+    expect(typeof service.frontendUrl).toBe('string');
+  });
+
+  it('should resolve emailProvider from ConfigService with default fallback', () => {
+    const service = module.get<AppConfigService>(AppConfigService);
+    // Default should be 'smtp' when EMAIL_PROVIDER is not explicitly set
+    expect(service.emailProvider).toBe('smtp');
+  });
+
+  it('should resolve throttle config from ConfigService', () => {
+    const service = module.get<AppConfigService>(AppConfigService);
+    // Values come from env vars set in jest.setup.ts
+    const result = service.throttle;
+    expect(result).toHaveProperty('ttl');
+    expect(result).toHaveProperty('limit');
+    expect(typeof result.ttl).toBe('string');
+    expect(typeof result.limit).toBe('string');
+  });
+
+  it('should be importable in other modules without duplicate providers', () => {
+    expect(() => module.get<AppConfigService>(AppConfigService)).not.toThrow();
+  });
+});

--- a/src/config/__tests__/app-config.service.spec.ts
+++ b/src/config/__tests__/app-config.service.spec.ts
@@ -1,0 +1,69 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { AppConfigService } from '../app-config.service';
+
+describe(AppConfigService.name, () => {
+  let service: AppConfigService;
+
+  const mockConfigService = {
+    get: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    jest.resetAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AppConfigService,
+        { provide: ConfigService, useValue: mockConfigService },
+      ],
+    }).compile();
+
+    service = module.get<AppConfigService>(AppConfigService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('frontendUrl', () => {
+    it('should return FRONTEND_URL from ConfigService', () => {
+      mockConfigService.get.mockReturnValue('https://app.example.com');
+
+      expect(service.frontendUrl).toBe('https://app.example.com');
+      expect(mockConfigService.get).toHaveBeenCalledWith('FRONTEND_URL');
+    });
+  });
+
+  describe('emailProvider', () => {
+    it('should return EMAIL_PROVIDER from ConfigService when set', () => {
+      mockConfigService.get.mockReturnValue('resend');
+
+      expect(service.emailProvider).toBe('resend');
+      expect(mockConfigService.get).toHaveBeenCalledWith('EMAIL_PROVIDER');
+    });
+
+    it('should return smtp as default when EMAIL_PROVIDER is not set', () => {
+      mockConfigService.get.mockReturnValue(undefined);
+
+      expect(service.emailProvider).toBe('smtp');
+    });
+  });
+
+  describe('throttle', () => {
+    it('should return throttle config with ttl and limit from ConfigService', () => {
+      mockConfigService.get
+        .mockImplementation((key: string) => {
+          if (key === 'THROTTLE_TTL') return '60';
+          if (key === 'THROTTLE_LIMIT') return '10';
+          return undefined;
+        });
+
+      const result = service.throttle;
+
+      expect(result).toEqual({ ttl: '60', limit: '10' });
+      expect(mockConfigService.get).toHaveBeenCalledWith('THROTTLE_TTL');
+      expect(mockConfigService.get).toHaveBeenCalledWith('THROTTLE_LIMIT');
+    });
+  });
+});

--- a/src/config/__tests__/env-exports.spec.ts
+++ b/src/config/__tests__/env-exports.spec.ts
@@ -1,0 +1,15 @@
+import { EnvironmentVariables, Environment } from '../env.validation';
+
+describe('env.validation exports', () => {
+  it('should export EnvironmentVariables class', () => {
+    expect(EnvironmentVariables).toBeDefined();
+    expect(typeof EnvironmentVariables).toBe('function');
+  });
+
+  it('should export Environment enum', () => {
+    expect(Environment).toBeDefined();
+    expect(Environment.DEVELOPMENT).toBe('development');
+    expect(Environment.PRODUCTION).toBe('production');
+    expect(Environment.TEST).toBe('test');
+  });
+});

--- a/src/config/app-config.module.ts
+++ b/src/config/app-config.module.ts
@@ -1,0 +1,9 @@
+import { Module, Global } from '@nestjs/common';
+import { AppConfigService } from './app-config.service';
+
+@Global()
+@Module({
+  providers: [AppConfigService],
+  exports: [AppConfigService],
+})
+export class AppConfigModule {}

--- a/src/config/app-config.service.ts
+++ b/src/config/app-config.service.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+@Injectable()
+export class AppConfigService {
+  constructor(private readonly config: ConfigService) {}
+
+  get frontendUrl(): string {
+    return this.config.get<string>('FRONTEND_URL');
+  }
+
+  get emailProvider(): string {
+    return this.config.get<string>('EMAIL_PROVIDER') ?? 'smtp';
+  }
+
+  get throttle(): { ttl: string; limit: string } {
+    return {
+      ttl: this.config.get<string>('THROTTLE_TTL'),
+      limit: this.config.get<string>('THROTTLE_LIMIT'),
+    };
+  }
+}

--- a/src/config/env.validation.ts
+++ b/src/config/env.validation.ts
@@ -1,7 +1,7 @@
 import { plainToInstance } from 'class-transformer';
 import { IsEnum, IsIn, IsNotEmpty, IsOptional, IsString, Matches, validateSync } from 'class-validator';
 
-enum Environment {
+export enum Environment {
   LOCAL = 'local',
   DEVELOPMENT = 'development',
   TEST = 'test',
@@ -9,7 +9,7 @@ enum Environment {
   PRODUCTION = 'production',
 }
 
-class EnvironmentVariables {
+export class EnvironmentVariables {
   @IsString()
   @IsOptional()
   HOST: string;

--- a/src/email/__tests__/email.listener.spec.ts
+++ b/src/email/__tests__/email.listener.spec.ts
@@ -1,0 +1,160 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { EmailListener } from '../listeners/email.listener';
+import { EmailService } from '../service/email.service';
+import { AppConfigService } from '../../config/app-config.service';
+
+describe(EmailListener.name, () => {
+  let listener: EmailListener;
+
+  const mockEmailService = {
+    sendBySlug: jest.fn().mockResolvedValue({ status: 'queued' }),
+  };
+
+  const mockConfigService = {
+    get frontendUrl() {
+      return 'https://app.example.com';
+    },
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        EmailListener,
+        { provide: EmailService, useValue: mockEmailService },
+        { provide: AppConfigService, useValue: mockConfigService },
+      ],
+    }).compile();
+
+    listener = module.get<EmailListener>(EmailListener);
+  });
+
+  it('should be defined', () => {
+    expect(listener).toBeDefined();
+  });
+
+  describe('handleUserRegistered', () => {
+    it('should send welcome email with verification link using frontendUrl from AppConfigService', async () => {
+      await listener.handleUserRegistered({
+        userId: 'user-1',
+        email: 'user@example.com',
+        name: 'John',
+        verificationToken: 'abc123',
+        lang: 'en',
+      });
+
+      expect(mockEmailService.sendBySlug).toHaveBeenCalledWith(
+        'welcome',
+        'user@example.com',
+        {
+          userName: 'John',
+          verificationLink: 'https://app.example.com/verify?token=abc123',
+        },
+        'en',
+      );
+    });
+
+    it('should use the exact frontendUrl value from AppConfigService, not process.env', async () => {
+      const customConfig = {
+        get frontendUrl() {
+          return 'https://custom.domain.org';
+        },
+      };
+
+      const module = await Test.createTestingModule({
+        providers: [
+          EmailListener,
+          { provide: EmailService, useValue: mockEmailService },
+          { provide: AppConfigService, useValue: customConfig },
+        ],
+      }).compile();
+
+      const customListener = module.get<EmailListener>(EmailListener);
+
+      await customListener.handleUserRegistered({
+        userId: 'user-1',
+        email: 'user@example.com',
+        name: 'John',
+        verificationToken: 'token999',
+        lang: 'en',
+      });
+
+      expect(mockEmailService.sendBySlug).toHaveBeenCalledWith(
+        'welcome',
+        'user@example.com',
+        {
+          userName: 'John',
+          verificationLink: 'https://custom.domain.org/verify?token=token999',
+        },
+        'en',
+      );
+    });
+  });
+
+  describe('handleForgotPassword', () => {
+    it('should send password reset email with reset link using frontendUrl from AppConfigService', async () => {
+      await listener.handleForgotPassword({
+        userId: 'user-1',
+        email: 'user@example.com',
+        name: 'John',
+        resetToken: 'reset456',
+        lang: 'es',
+      });
+
+      expect(mockEmailService.sendBySlug).toHaveBeenCalledWith(
+        'password-reset',
+        'user@example.com',
+        {
+          userName: 'John',
+          resetLink: 'https://app.example.com/reset-password?token=reset456',
+        },
+        'es',
+      );
+    });
+  });
+
+  describe('handleEmailChangeRequested', () => {
+    it('should send email change confirmation with link using frontendUrl from AppConfigService', async () => {
+      await listener.handleEmailChangeRequested({
+        userId: 'user-1',
+        newEmail: 'new@example.com',
+        name: 'John',
+        pendingEmailToken: 'token789',
+        lang: 'en',
+      });
+
+      expect(mockEmailService.sendBySlug).toHaveBeenCalledWith(
+        'email-change',
+        'new@example.com',
+        {
+          userName: 'John',
+          confirmationLink: 'https://app.example.com/confirm-email?token=token789',
+        },
+        'en',
+      );
+    });
+  });
+
+  describe('handleResendVerification', () => {
+    it('should resend verification email with link using frontendUrl from AppConfigService', async () => {
+      await listener.handleResendVerification({
+        userId: 'user-1',
+        email: 'user@example.com',
+        name: 'John',
+        verificationToken: 'verify012',
+        lang: 'en',
+      });
+
+      expect(mockEmailService.sendBySlug).toHaveBeenCalledWith(
+        'welcome',
+        'user@example.com',
+        {
+          userName: 'John',
+          verificationLink: 'https://app.example.com/verify?token=verify012',
+        },
+        'en',
+      );
+    });
+  });
+});

--- a/src/email/__tests__/email.service.spec.ts
+++ b/src/email/__tests__/email.service.spec.ts
@@ -1,0 +1,110 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { EmailService } from '../service/email.service';
+import { EmailProvider } from '../interfaces/email-provider.interface';
+import { EMAIL_PROVIDER_TOKEN } from '../constants/email.tokens';
+import { EmailLogRepository } from '../repository/email-log.repository';
+import { EmailTemplateService } from '../service/email-template.service';
+import { AppConfigService } from '../../config/app-config.service';
+
+describe(EmailService.name, () => {
+  let service: EmailService;
+
+  const mockProvider: EmailProvider = {
+    send: jest.fn().mockResolvedValue({ success: true, messageId: 'msg-1' }),
+  };
+
+  const mockTemplateService = {
+    resolve: jest.fn().mockResolvedValue({ subject: 'Test', html: '<p>Test</p>' }),
+    render: jest.fn().mockReturnValue({ subject: 'Rendered', html: '<p>Rendered</p>' }),
+  };
+
+  const mockLogRepository = {
+    create: jest.fn().mockResolvedValue({ id: 'log-1' }),
+    update: jest.fn(),
+  };
+
+  const mockEventEmitter = {
+    on: jest.fn(),
+    emit: jest.fn(),
+  };
+
+  const mockConfigService = {
+    get emailProvider() {
+      return 'resend';
+    },
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        EmailService,
+        { provide: EMAIL_PROVIDER_TOKEN, useValue: mockProvider },
+        { provide: EmailTemplateService, useValue: mockTemplateService },
+        { provide: EmailLogRepository, useValue: mockLogRepository },
+        { provide: EventEmitter2, useValue: mockEventEmitter },
+        { provide: AppConfigService, useValue: mockConfigService },
+      ],
+    }).compile();
+
+    service = module.get<EmailService>(EmailService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('sendBySlug', () => {
+    it('should use emailProvider from AppConfigService for log entry', async () => {
+      await service.sendBySlug('welcome', 'user@example.com', { userName: 'John' }, 'en');
+
+      expect(mockLogRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: 'resend',
+        }),
+      );
+    });
+
+    it('should use default smtp when AppConfigService returns default value', async () => {
+      const defaultConfigService = {
+        get emailProvider() {
+          return 'smtp';
+        },
+      };
+
+      const module = await Test.createTestingModule({
+        providers: [
+          EmailService,
+          { provide: EMAIL_PROVIDER_TOKEN, useValue: mockProvider },
+          { provide: EmailTemplateService, useValue: mockTemplateService },
+          { provide: EmailLogRepository, useValue: mockLogRepository },
+          { provide: EventEmitter2, useValue: mockEventEmitter },
+          { provide: AppConfigService, useValue: defaultConfigService },
+        ],
+      }).compile();
+
+      const svc = module.get<EmailService>(EmailService);
+      await svc.sendBySlug('welcome', 'user@example.com', { userName: 'John' }, 'en');
+
+      expect(mockLogRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: 'smtp',
+        }),
+      );
+    });
+  });
+
+  describe('sendDirect', () => {
+    it('should use emailProvider from AppConfigService for log entry', async () => {
+      await service.sendDirect('user@example.com', 'Test', '<p>Test</p>');
+
+      expect(mockLogRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: 'resend',
+        }),
+      );
+    });
+  });
+});

--- a/src/email/listeners/email.listener.ts
+++ b/src/email/listeners/email.listener.ts
@@ -10,17 +10,21 @@ import {
   UserRegisteredEvent,
 } from '../interfaces/email-events.interface';
 import { EmailService } from '../service/email.service';
+import { AppConfigService } from '../../config/app-config.service';
 
 @Injectable()
 export class EmailListener {
   private readonly logger = new Logger(EmailListener.name);
 
-  constructor(private readonly emailService: EmailService) {}
+  constructor(
+    private readonly emailService: EmailService,
+    private readonly config: AppConfigService,
+  ) {}
 
   @OnEvent(EmailEvents.USER_REGISTERED)
   async handleUserRegistered(payload: UserRegisteredEvent): Promise<void> {
     try {
-      const verificationLink = `${process.env.FRONTEND_URL}/verify?token=${payload.verificationToken}`;
+      const verificationLink = `${this.config.frontendUrl}/verify?token=${payload.verificationToken}`;
       await this.emailService.sendBySlug(
         'welcome',
         payload.email,
@@ -38,7 +42,7 @@ export class EmailListener {
   @OnEvent(EmailEvents.FORGOT_PASSWORD)
   async handleForgotPassword(payload: ForgotPasswordEvent): Promise<void> {
     try {
-      const resetLink = `${process.env.FRONTEND_URL}/reset-password?token=${payload.resetToken}`;
+      const resetLink = `${this.config.frontendUrl}/reset-password?token=${payload.resetToken}`;
       await this.emailService.sendBySlug(
         'password-reset',
         payload.email,
@@ -72,7 +76,7 @@ export class EmailListener {
   @OnEvent(EmailEvents.EMAIL_CHANGE_REQUESTED)
   async handleEmailChangeRequested(payload: EmailChangeRequestedEvent): Promise<void> {
     try {
-      const confirmationLink = `${process.env.FRONTEND_URL}/confirm-email?token=${payload.pendingEmailToken}`;
+      const confirmationLink = `${this.config.frontendUrl}/confirm-email?token=${payload.pendingEmailToken}`;
       await this.emailService.sendBySlug(
         'email-change',
         payload.newEmail,
@@ -106,7 +110,7 @@ export class EmailListener {
   @OnEvent(EmailEvents.RESEND_VERIFICATION)
   async handleResendVerification(payload: ResendVerificationEvent): Promise<void> {
     try {
-      const verificationLink = `${process.env.FRONTEND_URL}/verify?token=${payload.verificationToken}`;
+      const verificationLink = `${this.config.frontendUrl}/verify?token=${payload.verificationToken}`;
       await this.emailService.sendBySlug(
         'welcome',
         payload.email,

--- a/src/email/service/email.service.ts
+++ b/src/email/service/email.service.ts
@@ -4,6 +4,7 @@ import { EmailProvider } from '../interfaces/email-provider.interface';
 import { EMAIL_PROVIDER_TOKEN } from '../constants/email.tokens';
 import { EmailLogRepository } from '../repository/email-log.repository';
 import { EmailTemplateService } from './email-template.service';
+import { AppConfigService } from '../../config/app-config.service';
 
 export interface EmailSendEvent {
   to: string;
@@ -24,6 +25,7 @@ export class EmailService {
     private readonly templateService: EmailTemplateService,
     private readonly logRepository: EmailLogRepository,
     private readonly eventEmitter: EventEmitter2,
+    private readonly config: AppConfigService,
   ) {
     this.eventEmitter.on('email.send', async (event: EmailSendEvent) => {
       try {
@@ -106,6 +108,6 @@ export class EmailService {
   }
 
   private getProviderName(): string {
-    return process.env.EMAIL_PROVIDER || 'smtp';
+    return this.config.emailProvider;
   }
 }


### PR DESCRIPTION
- Export EnvironmentVariables type and Environment enum from env.validation.ts
- Create AppConfigService with typed getters (frontendUrl, emailProvider, throttle)
- Create AppConfigModule as @Global() for cross-module injection
- Migrate email.listener.ts and email.service.ts from process.env to AppConfigService
- Add 22 new tests (445 total passing)

Closes COU-141