### PR TITLE
ci: add unit + e2e test job to GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,98 @@
+name: Test
+
+on:
+  pull_request:
+    branches: [develop, staging, main]
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    services:
+      mongodb:
+        image: mongo:6.0.3
+        ports:
+          - 27017:27017
+        options: >-
+          --replSet rs0
+          --bind_ip_all
+        env:
+          MONGO_INITDB_DATABASE: api_user
+
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Initialize MongoDB replica set
+        run: |
+          mongosh --eval 'rs.initiate({_id: "rs0", members: [{_id: 0, host: "localhost:27017"}]})'
+          for i in $(seq 1 30); do
+            state=$(mongosh --quiet --eval 'try { rs.status().myState } catch(e) { 0 }')
+            [ "$state" = "1" ] && break
+            sleep 1
+          done
+          mongosh --eval 'db.getSiblingDB("admin").createUser({user: "dev_user", pwd: "dev_password", roles: [{role: "root", db: "admin"}]})'
+
+      - name: Run unit tests
+        run: npm test
+        env:
+          NODE_ENV: local
+          DATABASE_USER: dev_user
+          DATABASE_PASSWORD: dev_password
+          DATABASE_HOST: localhost
+          DATABASE_PORT: '27017'
+          DATABASE_NAME: api_user
+          JWT_SECRET: ci-test-jwt-secret
+          ENCRYPTION_PASSWORD: ci_test_encryption_password_32ch
+          CORS_ORIGINS: http://localhost:3000
+          DEBUG: 'false'
+          LOG_LEVEL: silent
+          EXAMPLE_MICROSERVICE_ENABLED: 'false'
+          REDIS_HOST: localhost
+          REDIS_PORT: '6379'
+          THROTTLE_LIMIT: '100'
+          THROTTLE_TTL: '60'
+
+      - name: Run e2e tests
+        run: npm run test:e2e
+        env:
+          NODE_ENV: local
+          DATABASE_USER: dev_user
+          DATABASE_PASSWORD: dev_password
+          DATABASE_HOST: localhost
+          DATABASE_PORT: '27017'
+          DATABASE_NAME: api_user
+          JWT_SECRET: ci-test-jwt-secret
+          ENCRYPTION_PASSWORD: ci_test_encryption_password_32ch
+          CORS_ORIGINS: http://localhost:3000
+          DEBUG: 'false'
+          LOG_LEVEL: silent
+          EXAMPLE_MICROSERVICE_ENABLED: 'false'
+          REDIS_HOST: localhost
+          REDIS_PORT: '6379'
+          THROTTLE_LIMIT: '100'
+          THROTTLE_TTL: '60'
+          LOGIN_THROTTLE_LIMIT: '100'
+          LOGIN_THROTTLE_TTL: '60'
+          REGISTER_THROTTLE_LIMIT: '100'
+          REGISTER_THROTTLE_TTL: '60'
+          FORGOT_PASSWORD_THROTTLE_LIMIT: '100'
+          FORGOT_PASSWORD_THROTTLE_TTL: '60'
+          MAX_LOGIN_ATTEMPTS: '100'
+          LOCKOUT_DURATION_MINUTES: '1'

--- a/openspec/changes/add-ci-test-job/proposal.md
+++ b/openspec/changes/add-ci-test-job/proposal.md
@@ -1,0 +1,61 @@
+# Proposal: Add CI Test Job (COU-216)
+
+## Intent
+
+PRs can pass CI with broken tests — no test job exists in the workflow lineup. Unit (717) and e2e (68/70) suites are green but unenforced. This change adds a `test` job that fails PRs when tests break.
+
+## Scope
+
+### In Scope
+- `test` job in a new GitHub Actions workflow: `npm ci` → `npm test` (unit) → `npm run test:e2e`
+- MongoDB + Redis service containers for e2e dependencies
+- Job triggers on PRs targeting develop/staging/main
+- Failure blocks merge
+
+### Out of Scope
+- Fixing the 2 failing e2e tests (COU-215 covers one; the other is known)
+- Coverage reporting or artifact uploads
+- Test matrix/parallelization
+- Caching `node_modules` (follow-up optimization)
+
+## Capabilities
+
+### New Capabilities
+- `ci-test-workflow`: GitHub Actions workflow that runs unit + e2e tests per PR, with MongoDB 6 + Redis 7 service containers
+
+### Modified Capabilities
+- None — no spec-level behavior change in application code
+
+## Approach
+
+Create `.github/workflows/test.yml` modeled after existing workflow conventions. Use `ubuntu-latest`, Node 22 (per `.nvmrc`), MongoDB 6.0 and Redis 7 service containers with root credentials matching `global-setup.js` (`dev_user`/`dev_password`). Set `DATABASE_HOST=localhost`, `REDIS_HOST=localhost`, and e2e env vars (`JWT_SECRET`, `ENCRYPTION_PASSWORD`, `DATABASE_NAME=api_user`). Run e2e with `--forceExit` to prevent open-handle hangs.
+
+## Affected Areas
+
+| Area | Impact | Description |
+|------|--------|-------------|
+| `.github/workflows/` | New | `test.yml` workflow file |
+| `openspec/config.yaml` | Modified | Add `ci_command` to testing config |
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| E2e test flakiness blocks legitimate PRs | Medium | Retry on `workflow_dispatch`; mark known-flaky tests as follow-up |
+| Service container auth mismatch with `global-setup.js` | Low | Match `MONGO_INITDB_ROOT_USERNAME`/`PASSWORD` to hardcoded `dev_user`/`dev_password` |
+| CI runtime exceeds free-tier limits | Low | Unit ~30s, e2e fits within runner timeout |
+
+## Rollback Plan
+
+Remove `.github/workflows/test.yml`, revert `config.yaml`. No DB migrations or code changes.
+
+## Dependencies
+
+- None (CI-only change, no application code)
+
+## Success Criteria
+
+- [ ] PR checks include test results; failures block merge
+- [ ] Unit suite: 717 tests pass, coverage thresholds met (55% stmts)
+- [ ] E2e suite: runs against service containers, ≥68/70 pass
+- [ ] Workflow completes in <5 min

--- a/openspec/changes/add-ci-test-job/tasks.md
+++ b/openspec/changes/add-ci-test-job/tasks.md
@@ -1,0 +1,36 @@
+# Tasks: Add CI Test Job (COU-216)
+
+## Review Workload Forecast
+
+| Field | Value |
+|-------|-------|
+| Estimated changed lines | 60–80 |
+| 400-line budget risk | Low |
+| Chained PRs recommended | No |
+| Suggested split | Single PR |
+| Delivery strategy | ask-on-risk |
+| Chain strategy | size-exception |
+
+Decision needed before apply: Yes
+Chained PRs recommended: No
+Chain strategy: size-exception
+400-line budget risk: Low
+
+### Suggested Work Units
+
+| Unit | Goal | Likely PR | Focused test command | Runtime harness | Rollback boundary |
+|------|------|-----------|----------------------|-----------------|-------------------|
+| 1 | Add test workflow + config | PR 1 | `npm test && npm run test:e2e` | `gh workflow run test.yml --ref <branch>` | Delete `.github/workflows/test.yml`, revert `config.yaml` |
+
+## Phase 1: CI Workflow
+
+- [ ] 1.1 Create `.github/workflows/test.yml` with `pull_request` trigger for develop/staging/main, Node 20 (matches `.nvmrc`), MongoDB 6 + Redis 7 service containers, `DATABASE_USER=dev_user`, `DATABASE_PASSWORD=dev_password`, `DATABASE_HOST=localhost`, `REDIS_HOST=localhost`, `DATABASE_NAME=api_user`, and placeholder secrets for `JWT_SECRET` + `ENCRYPTION_PASSWORD`
+- [ ] 1.2 Add `ci_command: npm test && npm run test:e2e` to `openspec/config.yaml` under `testing`
+- [ ] 1.3 Push a branch + open a draft PR to verify workflow triggers and passes against this branch
+
+## Phase 2: Verification
+
+- [ ] 2.1 Confirm all 717 unit tests pass in CI
+- [ ] 2.2 Confirm ≥68/70 e2e tests pass in CI
+- [ ] 2.3 Confirm workflow completes in under 5 minutes
+- [ ] 2.4 Confirm test failure blocks merge on the PR


### PR DESCRIPTION
## Summary

Adds a CI test workflow triggered on PRs to develop, staging, and main.

### Changes
- New `.github/workflows/test.yml` with MongoDB 6.0 + Redis 7 service containers
- Runs `npm ci`, `npm test` (717 unit tests), and `npm run test:e2e` (70 tests)
- Initializes MongoDB replica set + creates `dev_user` before tests

Refs COU-216